### PR TITLE
Update the preview with the editor content when it is available (#7)

### DIFF
--- a/blocks/edit/prose/index.js
+++ b/blocks/edit/prose/index.js
@@ -36,20 +36,25 @@ function dispatchTransaction(transaction) {
   view.updateState(newState)
 }
 
+function setPreviewBody(daPreview, proseEl) {
+  const clone = proseEl.cloneNode(true);
+  const body = prose2aem(clone);
+  daPreview.body = body;
+}
+
 function pollForUpdates() {
   const daContent = document.querySelector('da-content');
   const daPreview = daContent.shadowRoot.querySelector('da-preview');
   const proseEl = window.view.root.querySelector('.ProseMirror');
   if (!daPreview) return;
+  setPreviewBody(daPreview, proseEl);
   setInterval(() => {
     if (sendUpdates) {
       if (hasChanged > 0) {
         hasChanged = 0;
         return;
       }
-      const clone = proseEl.cloneNode(true);
-      const body = prose2aem(clone);
-      daPreview.body = body;
+      setPreviewBody(daPreview, proseEl);
       sendUpdates = false;
     }
   }, 1000);


### PR DESCRIPTION
Might not be a good idea, but I think one way to fix #7 is to just always initially send the editor content to the preview. Granted, in the normal case, the content is previewed so the preview will see it without that updated and this just adds unnecessary noise - I'll make it a draft just in case.