### PR TITLE
Fix pop-up window on create new document in safari

### DIFF
--- a/blocks/browse/da-browse/da-browse.js
+++ b/blocks/browse/da-browse/da-browse.js
@@ -80,9 +80,9 @@ export default class DaBrowse extends LitElement {
       const ext = 'html';
       path += `.${ext}`;
       const blob = new Blob([''], { type: 'text/html' });
-      await saveToDa({ blob, path, preview: isDoc });
       const editPath = this.getEditPath({ path, ext });
       window.open(editPath, '_blank');
+      await saveToDa({ blob, path, preview: isDoc });
     } else {
       await saveToDa({ path });
     }


### PR DESCRIPTION
I think fixing #12 is as simple as just doing the window.open before awaiting the document creation in da.

Fix: #12